### PR TITLE
Prevent bot init on rake commands

### DIFF
--- a/bot/artbot.rb
+++ b/bot/artbot.rb
@@ -5,7 +5,11 @@
 
 
 module SlackBotHooks
-  @art = Art.all
+  # create array from all art id's
+  @art = Art.pluck(:id)
+
+  # stores last art piece shared
+  @last_art
   def open(event)
     p "open event triggered"
     nil
@@ -13,11 +17,11 @@ module SlackBotHooks
 
   def message(event)
     p "Message event triggered"
-    puts @art
     data = JSON.parse(event.data)
     # uncomment line below to see full set of incoming data
     p data
     msg = data['text']
+
     if msg =~ /art me/i
       p "art me triggered"
       p "returning #{Art.all.sample.image} "
@@ -26,6 +30,7 @@ module SlackBotHooks
         text: Art.all.sample.image,
         channel: data['channel'],
       }
+
     elsif msg =~ /art vandelay/i
       p "art vandeley triggered"
       {
@@ -33,6 +38,7 @@ module SlackBotHooks
         text: "https://www.youtube.com/watch?v=j0Xtsi7Jcec",
         channel: data['channel']
       }
+
     elsif msg =~ /.*weather.*(in|at) (?<location>\w*)\?$/i
       m = data['text'].match(/.*weather.*(in|at) (?<location>\w*)\?$/i)
       {
@@ -40,6 +46,7 @@ module SlackBotHooks
         text: "The weather in #{m[:location]} is nice!",
         channel: data['channel']
       }
+
     elsif msg =~ /hi @artbot/i
       p "hi @artbot triggered"
       p "returning #{data['user']}"
@@ -48,6 +55,7 @@ module SlackBotHooks
         text: "Hi, <@#{data['user']}>.",
         channel: data['channel']
       }
+
     elsif msg == "<@#{$bot_id}> artists"
       p "@artbot artists triggered"
       res = Artist.all.map {|x| x.name}.join("\n")
@@ -57,6 +65,7 @@ module SlackBotHooks
         text: "#{res}",
         channel: data['channel']
       }
+      
     end
 
   end

--- a/bot/artbot.rb
+++ b/bot/artbot.rb
@@ -78,9 +78,7 @@ module SlackBotHooks
         text: "#{res}",
         channel: data['channel']
       }
-<<<<<<< HEAD
 
-=======
     elsif msg == "<@#{$bot_id}> help"
       p "@artbot help triggered"
       {
@@ -88,7 +86,6 @@ module SlackBotHooks
         text: "*For a list of commands, type:*\n<art*me> to get a random art work \nhi <nameofthebot> to get a greeting back\n@<nameofthebot> artists to get a list of artists back\n@<name of the bot>help to get this list of commands :)",
         channel: data['channel']
       }
->>>>>>> master
     end
 
   end

--- a/bot/artbot.rb
+++ b/bot/artbot.rb
@@ -5,7 +5,7 @@
 
 
 module SlackBotHooks
-
+  @art = Art.all
   def open(event)
     p "open event triggered"
     nil
@@ -13,6 +13,7 @@ module SlackBotHooks
 
   def message(event)
     p "Message event triggered"
+    puts @art
     data = JSON.parse(event.data)
     # uncomment line below to see full set of incoming data
     p data

--- a/bot/artbot.rb
+++ b/bot/artbot.rb
@@ -15,7 +15,7 @@ module SlackBotHooks
     nil
   end
 
-  def message(event)
+  def message(event, bot_id)
 
     p "Message event triggered"
     data = JSON.parse(event.data)
@@ -59,7 +59,7 @@ module SlackBotHooks
         channel: data['channel']
       }
 
-    elsif msg == "hi <@#{$bot_id}>"
+    elsif msg == "hi <@#{bot_id}>"
       p "hi @artbot triggered"
       res = "Hi, <@#{data['user']}>."
       p "returning #{res}"
@@ -69,7 +69,7 @@ module SlackBotHooks
         channel: data['channel']
       }
 
-    elsif msg == "<@#{$bot_id}> artists"
+    elsif msg == "<@#{bot_id}> artists"
       p "@artbot artists triggered"
       res = Artist.all.map {|x| x.name}.join("\n")
       p "returning #{res}"
@@ -79,7 +79,7 @@ module SlackBotHooks
         channel: data['channel']
       }
 
-    elsif msg == "<@#{$bot_id}> help"
+    elsif msg == "<@#{bot_id}> help"
       p "@artbot help triggered"
       {
         type: 'message',
@@ -106,9 +106,10 @@ module SlackBotEM
     })
 
     rc = JSON.parse(rc.body)
-    $bot_id = rc['self']['id']
+    #capture @@bot_id to use in message
+    @@bot_id = rc['self']['id']
     url = rc['url']
-    p "bot_id = #{$bot_id}"
+    p "bot_id = #{@@bot_id}"
 
     EM.next_tick {
       EM.run do
@@ -136,7 +137,7 @@ module SlackBotEM
   def self.on(signal_type, event=nil)
     case signal_type
       when :open    then open(event)
-      when :message then message(event)
+      when :message then message(event, @@bot_id)
       when :close   then close(event)
     end
   end

--- a/bot/artbot.rb
+++ b/bot/artbot.rb
@@ -6,10 +6,10 @@
 
 module SlackBotHooks
   # create array from all art id's
-  @art = Art.pluck(:id)
+  @@art = Art.pluck(:id)
 
   # stores last art piece shared
-  @last_art
+  @@current_art = nil
   def open(event)
     p "open event triggered"
     nil
@@ -24,12 +24,22 @@ module SlackBotHooks
 
     if msg =~ /art me/i
       p "art me triggered"
-      p "returning #{Art.all.sample.image} "
-      {
-        type: 'message',
-        text: Art.all.sample.image,
-        channel: data['channel'],
-      }
+      #remove @@current_art from @@art array
+      if @@art.empty?
+        {
+          type: 'message',
+          text: "Out of art! Enter `@artbot reset_art` to reset the art library.",
+          channel: data['channel'],
+        }
+      else
+        # remove random ID from @@art and update @@current_art to the full Art piec from the DB
+        @@current_art = Art.find_by_id(@@art.delete(@@art.sample))
+        {
+          type: 'message',
+          text: "#{@@current_art.image}",
+          channel: data['channel'],
+        }
+      end
 
     elsif msg =~ /art vandelay/i
       p "art vandeley triggered"
@@ -65,7 +75,7 @@ module SlackBotHooks
         text: "#{res}",
         channel: data['channel']
       }
-      
+
     end
 
   end

--- a/config/initializers/slack_bot.rb
+++ b/config/initializers/slack_bot.rb
@@ -1,3 +1,5 @@
-require_relative "./../../bot/artbot.rb"
-
-SlackBotEM.start( ENV['SLACK_API_TOKEN'] )
+unless ( File.basename($0) == 'rake')
+   # Initializer code
+   require_relative "./../../bot/artbot.rb"
+   SlackBotEM.start( ENV['SLACK_API_TOKEN'] )
+end


### PR DESCRIPTION
Class variables in artbot.rb appear to cause issues because they are expecting to be initialized with values that are expected from communication with slack's servers. This update prevents artbot.rb from being initialized during rake commands.
