### PR TITLE
prevent bot init on rake

### DIFF
--- a/config/initializers/slack_bot.rb
+++ b/config/initializers/slack_bot.rb
@@ -1,3 +1,5 @@
-require_relative "./../../bot/artbot.rb"
-
-SlackBotEM.start( ENV['SLACK_API_TOKEN'] )
+unless ( File.basename($0) == 'rake')
+   # exclude artbot from initializing during 'rake' commands
+   require_relative "./../../bot/artbot.rb"
+   SlackBotEM.start( ENV['SLACK_API_TOKEN'] )
+end


### PR DESCRIPTION
This update prevents artbot.rb from being initialized during rake commands.
Why? Class variables in artbot.rb appeared to cause issues because they are expecting to be initialized with values that are expected from communication with slack's servers.
