### PR TITLE
Fix for missing foreign key, artist_id in arts table

### DIFF
--- a/app/views/arts/index.html.erb
+++ b/app/views/arts/index.html.erb
@@ -9,8 +9,8 @@
           <h3 class="list-group-item-heading"> &ldquo;<%= art.title %>&rdquo; </h3>
         <% end %>
         <p class="list-group-item-text">
-          <strong>Artist:</strong> <%= art.artist.name %><br />
-          <strong>Nationality:</strong> <%= art.artist.nationality %><br />
+          <strong>Artist:</strong> <%= art.artist.try(:name) %><br />
+          <strong>Nationality:</strong> <%= art.artist.try(:nationality) %><br />
           <strong>Year:</strong> <%= art.year %><br />
           <strong>Era:</strong> <%= art.century %> century<br />
           <strong>Medium:</strong> <%= art.medium %><br />


### PR DESCRIPTION
This is a fix for the error i get  when visiting arts#index:

**ActionView::Template::Error (undefined method `name' for nil:NilClass):**
     9:           <h3 class="list-group-item-heading"> &ldquo;<%= art.title %>&rdquo; </h3>
    10:         <% end %>
    11:         <p class="list-group-item-text">
    12:           <strong>Artist:</strong> <%= art.artist.name %><br />
    13:           <strong>Nationality:</strong> <%= art.artist.nationality %><br />
    14:           <strong>Year:</strong> <%= art.year %><br />
    15:           <strong>Era:</strong> <%= art.century %> century<br />
  app/views/arts/index.html.erb:12:in `block in _app_views_arts_index_html_erb__628773304395914927_70110217438500'
  app/views/arts/index.html.erb:2:in`_app_views_arts_index_html_erb__628773304395914927_70110217438500'

http://stackoverflow.com/questions/16153818/development-log-actionviewtemplateerror-undefined-method-name-for-nilni
